### PR TITLE
Fix: update bible model to fix DB error on creating table

### DIFF
--- a/src/Models/Bibles/Bible.ts
+++ b/src/Models/Bibles/Bible.ts
@@ -15,6 +15,6 @@ export class Bible extends EntityBase {
     public description: string;
 
     @ApiProperty({ enum: Language })
-    @Column({ enum: Language })
+    @Column({ type: 'enum', enum: Language })
     public language: Language;
 }


### PR DESCRIPTION
This will fix db sync error bellow:

`Error: ER_PARSE_ERROR: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '('en') NOT NULL, UNIQUE INDEX `IDX_06459cd0db29f4e91dd1898060` (`name`), PRIMARY' at line 1`